### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/bencode.asd
+++ b/bencode.asd
@@ -1,8 +1,5 @@
 ;;; -*- Mode: Lisp -*-
 
-(defpackage #:bencode-system (:use #:asdf #:cl))
-(in-package #:bencode-system)
-
 (defsystem #:bencode
   :description "Bencode"
   :version "3.0.1"
@@ -13,15 +10,13 @@
                (:file "encode" :depends-on ("package" "dictionary"))
 	       (:file "decode" :depends-on ("package" "dictionary")))
   :depends-on (#:flexi-streams)
-  :in-order-to ((test-op (test-op #:bencode-test))))
+  :in-order-to ((test-op (test-op #:bencode/test))))
 
-(defsystem #:bencode-test
+(defsystem #:bencode/test
   :description "Test system of Bencode"
   :author "Johan Andersson <nilsjohanandersson@gmail.com>"
   :license "MIT"
   :serial t
   :depends-on (#:bencode #:hu.dwim.stefil #:check-it)
-  :components ((:file "test")))
-
-(defmethod perform ((o test-op) (c (eql (find-system :bencode-test))))
-  (funcall (intern (symbol-name :test-all) (find-package :bencode-test))))
+  :components ((:file "test"))
+  :perform (test-op (o c) (symbol-call :bencode-test :test-all)))


### PR DESCRIPTION
ASDF3 recommends a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
